### PR TITLE
Requesting all versions (incl. snapshots) from the extension providers

### DIFF
--- a/models/LexService.cfc
+++ b/models/LexService.cfc
@@ -85,7 +85,7 @@ component accessors="true" {
             providerExtensions = { };
             for ( var providerData in providers ) {
                 for ( var source in providerData.info ) {
-                    var req = makeHTTPRequest( source & '/rest/extension/provider/info' );
+                    var req = makeHTTPRequest( source & '/rest/extension/provider/info?type=all' );
                     var resData = deserializeJSON( req.filecontent );
                     resData.extensions.data.each( ( row ) => {
                         var extension = row.reduce( ( ext, column, i ) => {


### PR DESCRIPTION
This is a simple change to the info URL so that the extension providers (specifically Lucee's) return all versions of an extension, incl. snapshots.

